### PR TITLE
bug: grid range of initial val

### DIFF
--- a/FP-CODE/AS_SEL.m
+++ b/FP-CODE/AS_SEL.m
@@ -1,5 +1,5 @@
 function [H_sel] = AS_SEL(H,N,G,K,P_max,sigma_2)
-for n=1:N
+for n=1:G
     ini_a(n)=H(n,:)*H(n,:)';
 end
 [~,indm_ini]=max(abs(ini_a));


### PR DESCRIPTION
Seems like the selection range of initial antenna for 'Fast AS' scheme is wrong. Should be G (grid)  rather than N (number of antennas)

Slightly improves the performance of 'Fast AS' scheme (by ~0.2 bits/s/Hz).